### PR TITLE
[FIX] crm_facebook_leads: Missing _description attr on clases

### DIFF
--- a/crm_facebook_leads/models/lead.py
+++ b/crm_facebook_leads/models/lead.py
@@ -106,6 +106,7 @@ class UtmMedium(models.Model):
 
 class UtmAdset(models.Model):
     _name = 'utm.adset'
+    _description = 'Utm Adset'
 
     name = fields.Char()
     facebook_adset_id = fields.Char()


### PR DESCRIPTION
I miss a model

![image](https://user-images.githubusercontent.com/10233975/60551183-1df21800-9cf0-11e9-815d-f3f4ae1f7b6b.png)
