### PR TITLE
T#43630 [13.0] crm_facebook_leads: fix form inheritance

### DIFF
--- a/crm_facebook_leads/views/crm_view.xml
+++ b/crm_facebook_leads/views/crm_view.xml
@@ -13,34 +13,12 @@
         <field name="code" eval="'model.get_facebook_leads()'"/>
     </record>
 
-    <record id="crm_case_form_view_leads" model="ir.ui.view">
+    <record id="crm_lead_view_form" model="ir.ui.view">
         <field name="name">crm.lead.form</field>
         <field name="model">crm.lead</field>
-        <field name="inherit_id" ref="crm.crm_case_form_view_leads"/>
+        <field name="inherit_id" ref="crm.crm_lead_view_form"/>
         <field name="arch" type="xml">
             <xpath expr='//page[@name="extra"]' position='after'>
-                <page name="categorization" string="Facebook Info">
-                    <group name="facebook_info" string="Facebook Info">
-                        <field name="facebook_lead_id"/>
-                        <field name="facebook_date_create"/>
-                        <field name="facebook_page_id"/>
-                        <field name="facebook_form_id"/>
-                        <field name="facebook_adset_id"/>
-                        <field name="facebook_ad_id"/>
-                        <field name="facebook_campaign_id"/>
-                        <field name="facebook_is_organic"/>
-                    </group>
-                </page>
-            </xpath>
-        </field>
-    </record>
-
-    <record id="crm_case_form_view_oppor" model="ir.ui.view">
-        <field name="name">crm.lead.form</field>
-        <field name="model">crm.lead</field>
-        <field name="inherit_id" ref="crm.crm_case_form_view_oppor"/>
-        <field name="arch" type="xml">
-            <xpath expr='//page[@name="lead"]' position='after'>
                 <page name="categorization" string="Facebook Info">
                     <group name="facebook_info" string="Facebook Info">
                         <field name="facebook_lead_id"/>


### PR DESCRIPTION
Before this MR, the module was inheriting [`crm.crm_case_form_view_leads`](https://github.com/odoo/odoo/blob/12.0/addons/crm/views/crm_lead_views.xml#L40) and [`crm.crm_case_form_view_oppor`](https://github.com/odoo/odoo/blob/12.0/addons/crm/views/crm_lead_views.xml#L449) to add the facebook fields to the leads.

Those views were removed and replaced with [`crm.crm_lead_view_form`](https://github.com/odoo/odoo/blob/13.0/addons/crm/views/crm_lead_views.xml#L41) (both on leads and opportunities).

This MR replaces the inheritance to use the new ID, and removes the second inheritance as it is no longer necessary.

![image](https://user-images.githubusercontent.com/8657959/101659755-043c2080-3a0c-11eb-9527-af0e42e43912.png)
