### PR TITLE
Include archived leads to prevent error due constraint

### DIFF
--- a/crm_facebook_leads/models/lead.py
+++ b/crm_facebook_leads/models/lead.py
@@ -253,7 +253,8 @@ class CrmLead(models.Model):
             with self.env.cr.savepoint():
                 for lead in data:
                     lead = self.process_lead_field_data(lead)
-                    if not self.search([('facebook_lead_id', '=', lead.get('id'))]):
+                    if not self.search([('facebook_lead_id', '=', lead.get('id')),
+                                        '|', ('active', '=', False), ('active', '=', True)]):
                         self.lead_creation(lead, form)
 
             if response.get('paging', {}).get('next'):

--- a/crm_facebook_leads/models/lead.py
+++ b/crm_facebook_leads/models/lead.py
@@ -253,8 +253,8 @@ class CrmLead(models.Model):
             with self.env.cr.savepoint():
                 for lead in data:
                     lead = self.process_lead_field_data(lead)
-                    if not self.search([('facebook_lead_id', '=', lead.get('id')),
-                                        '|', ('active', '=', False), ('active', '=', True)]):
+                    if not self.with_context(active_test=False).search([('facebook_lead_id', '=', lead.get('id'))],
+                                                                       limit=1):
                         self.lead_creation(lead, form)
 
             if response.get('paging', {}).get('next'):


### PR DESCRIPTION
Apparently the search method only gives a match if the lead is active. But if some lead has been mark as lost or archived it does not match so it will try to create a lead and of course produce an error that will stop the lead processing.