### PR TITLE
Fix: Prevents infinite loop

### DIFF
--- a/crm_facebook_leads/models/lead.py
+++ b/crm_facebook_leads/models/lead.py
@@ -258,8 +258,8 @@ class CrmLead(models.Model):
                         self.lead_creation(lead, form)
 
             if response.get('paging', {}).get('next'):
-                res = requests.get(response['paging']['next']).json()
-                data = res.get('data', False)
+                response = requests.get(response['paging']['next']).json()
+                data = response.get('data', False)
             else:
                 data = False
 


### PR DESCRIPTION
This fix an infinite loop that happens when there are multiple pages in in the lead information from facebook.

The `if` statement checks if there are more pages so it changes the `data` variable with the information corresponding to the next page. In this case, as the `response` variable is never updated or reused, it keeps loading _only_ the second page of the facebook leads every time, which leads to an infinite loop that never ends as it will always enter the `if` statement reaching no end.